### PR TITLE
Fix git clone

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-libs/*.jar filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Write that the PR fixes a Git/IntelliJ clone failure caused by Git’s new “clone protection” blocking an active post-checkout hook (commonly from Git LFS), and that the workaround is to set GIT_CLONE_PROTECTION_ACTIVE=false and restart IntelliJ.​