### PR TITLE
Refactor item to base64 serialization

### DIFF
--- a/core/src/main/java/dev/nandi0813/practice/util/ItemSerializationUtil.java
+++ b/core/src/main/java/dev/nandi0813/practice/util/ItemSerializationUtil.java
@@ -4,10 +4,10 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.io.BukkitObjectInputStream;
 import org.bukkit.util.io.BukkitObjectOutputStream;
 import org.jetbrains.annotations.Nullable;
-import org.yaml.snakeyaml.external.biz.base64Coder.Base64Coder;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.Base64;
 
 public enum ItemSerializationUtil {
     ;
@@ -28,7 +28,7 @@ public enum ItemSerializationUtil {
             }
 
             dataOutput.close();
-            return Base64Coder.encodeLines(outputStream.toByteArray());
+            return Base64.getEncoder().encodeToString(outputStream.toByteArray());
         } catch (Exception e) {
             Common.sendConsoleMMMessage("<red>Error encoding base 64 itemstack.");
         }
@@ -41,7 +41,7 @@ public enum ItemSerializationUtil {
         }
 
         try {
-            ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64Coder.decodeLines(data));
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64.getMimeDecoder().decode(data));
             BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream);
 
             ItemStack[] items = new ItemStack[dataInput.readInt()];


### PR DESCRIPTION
snakeyaml deprecated the external util class Base64Coder since [snakeyaml 2.3](https://github.com/snakeyaml/snakeyaml/commit/3f0bedad5917490a1f7ef56a0920b5b93b214ade)

It replaced it using Java's built-in Base64 util (java.util.Base64), which is better and more standard. So, for the consideration of the future, it is not appropriate to continue relying on snakeyaml's Base64Coder util class.

In here, I use Base64.getMimeDecoder() for the base64 decoding, to be compatible with old data stored in entity inventory's PDC that is using the old standard (the Base64Coder is using [MIME type](https://docs.oracle.com/javase/8/docs/api/java/util/Base64.html#:~:text=MIME)).
And use the basic Base64 encoder to encode the item.