### PR TITLE
fix(firework): prevent cooldown spam/hang on held clicks

### DIFF
--- a/spigot_modern/src/main/java/dev/nandi0813/practice_modern/listener/FireworkRocketCooldownListener.java
+++ b/spigot_modern/src/main/java/dev/nandi0813/practice_modern/listener/FireworkRocketCooldownListener.java
@@ -57,10 +57,9 @@ public class FireworkRocketCooldownListener implements Listener {
         // Deduplicate: PlayerInteractEvent fires once per hand (MAIN + OFF), skip the second call this tick
         UUID uuid = player.getUniqueId();
         if (!handledThisTick.add(uuid)) {
+            handledThisTick.remove(uuid);
             return;
         }
-        // Clean up after this tick so the next click is processed normally
-        Bukkit.getScheduler().runTask(ZonePractice.getInstance(), () -> handledThisTick.remove(uuid));
 
         // Check if player is in FFA
         FFA ffa = FFAManager.getInstance().getFFAByPlayer(player);
@@ -102,5 +101,4 @@ public class FireworkRocketCooldownListener implements Listener {
             );
         }
     }
-
 }


### PR DESCRIPTION
PlayerInteractEvent fires twice (MAIN_HAND + OFF_HAND) in same tick.

Bug: !handledThisTick.add(uuid) returned early before scheduler cleanup,
preventing UUID removal → permanent cooldown hang on held clicks.

Fix: Add handledThisTick.remove(uuid) in early return branch to manually
reset Set state. Ensures clean slate for next tick without scheduler spam.

Prevents cooldown "stuck" state during elytra boost spam-clicking.