### PR TITLE
High ram usage fix

### DIFF
--- a/core/src/main/java/dev/nandi0813/practice/manager/ladder/abstraction/playercustom/CustomLadder.java
+++ b/core/src/main/java/dev/nandi0813/practice/manager/ladder/abstraction/playercustom/CustomLadder.java
@@ -153,6 +153,7 @@ public class CustomLadder extends Ladder {
 
     public MainGUI getMainGUI() {
         if (mainGUI == null) {
+            // The custom kit editor holds inventories and item snapshots, so defer it until someone opens it.
             mainGUI = new MainGUI(this);
         }
         return mainGUI;

--- a/core/src/main/java/dev/nandi0813/practice/manager/ladder/abstraction/playercustom/CustomLadder.java
+++ b/core/src/main/java/dev/nandi0813/practice/manager/ladder/abstraction/playercustom/CustomLadder.java
@@ -41,7 +41,7 @@ public class CustomLadder extends Ladder {
     private static final String HEALTH_BELOW_NAME_PATH = ".settings.health-below-name";
     private static final String KIT_DATA_PATH = ".kit-data";
 
-    private final MainGUI mainGUI;
+    private MainGUI mainGUI;
 
     private static final List<MatchType> MATCH_TYPES = new ArrayList<>();
     static {
@@ -71,7 +71,6 @@ public class CustomLadder extends Ladder {
         this.matchTypes = new ArrayList<>(MATCH_TYPES);
 
         this.getData();
-        this.mainGUI = new MainGUI(this);
     }
 
     public CustomLadder(final CustomLadder customLadder, final Profile profile, final String mapPath) {
@@ -79,8 +78,6 @@ public class CustomLadder extends Ladder {
 
         this.config = profile.getFile().getConfig();
         this.mapPath = mapPath;
-
-        this.mainGUI = new MainGUI(this);
     }
 
     @Override
@@ -152,6 +149,13 @@ public class CustomLadder extends Ladder {
     @Override
     public boolean isEnabled() {
         return isReadyToEnable();
+    }
+
+    public MainGUI getMainGUI() {
+        if (mainGUI == null) {
+            mainGUI = new MainGUI(this);
+        }
+        return mainGUI;
     }
 
     /**

--- a/core/src/main/java/dev/nandi0813/practice/manager/profile/Profile.java
+++ b/core/src/main/java/dev/nandi0813/practice/manager/profile/Profile.java
@@ -219,7 +219,7 @@ public class Profile {
             this.customLadders.removeLast();
         }
 
-        this.playerCustomKitSelector = new PlayerCustomKitSelector(this);
+        this.playerCustomKitSelector = null;
     }
 
     public void setSelectedCustomLadder(CustomLadder customLadder) {
@@ -232,6 +232,23 @@ public class Profile {
         }
 
         this.selectedCustomLadder = customLadder;
+    }
+
+    public ProfileSettingsGui getSettingsGui() {
+        if (settingsGui == null) {
+            settingsGui = new ProfileSettingsGui(this);
+        }
+        return settingsGui;
+    }
+
+    public PlayerCustomKitSelector getPlayerCustomKitSelector() {
+        if (playerCustomKitSelector == null) {
+            if (group == null) {
+                throw new IllegalStateException("Cannot create custom kit selector without an assigned group.");
+            }
+            playerCustomKitSelector = new PlayerCustomKitSelector(this);
+        }
+        return playerCustomKitSelector;
     }
 
     public void setStatus(ProfileStatus status) {

--- a/core/src/main/java/dev/nandi0813/practice/manager/profile/Profile.java
+++ b/core/src/main/java/dev/nandi0813/practice/manager/profile/Profile.java
@@ -236,6 +236,7 @@ public class Profile {
 
     public ProfileSettingsGui getSettingsGui() {
         if (settingsGui == null) {
+            // Build this GUI only when a player opens it to avoid holding one per stored profile.
             settingsGui = new ProfileSettingsGui(this);
         }
         return settingsGui;
@@ -246,6 +247,7 @@ public class Profile {
             if (group == null) {
                 throw new IllegalStateException("Cannot create custom kit selector without an assigned group.");
             }
+            // This selector references per-profile custom kit menus, so keep it lazy to reduce idle RAM use.
             playerCustomKitSelector = new PlayerCustomKitSelector(this);
         }
         return playerCustomKitSelector;

--- a/core/src/main/java/dev/nandi0813/practice/manager/profile/ProfileManager.java
+++ b/core/src/main/java/dev/nandi0813/practice/manager/profile/ProfileManager.java
@@ -125,6 +125,7 @@ public class ProfileManager {
 
     public void loadProfileInfo(Profile profile) {
         profile.getStats().setDivision(DivisionManager.getInstance().getDivision(profile));
+        // Profile-specific GUIs are created on demand now, so startup only refreshes lightweight profile data.
     }
 
     public void saveProfiles() {

--- a/core/src/main/java/dev/nandi0813/practice/manager/profile/ProfileManager.java
+++ b/core/src/main/java/dev/nandi0813/practice/manager/profile/ProfileManager.java
@@ -4,7 +4,6 @@ import dev.nandi0813.api.Event.NewPlayerJoin;
 import dev.nandi0813.practice.ZonePractice;
 import dev.nandi0813.practice.manager.backend.MysqlManager;
 import dev.nandi0813.practice.manager.division.DivisionManager;
-import dev.nandi0813.practice.manager.gui.guis.profile.ProfileSettingsGui;
 import dev.nandi0813.practice.util.Common;
 import dev.nandi0813.practice.util.StartUpCallback;
 import lombok.Getter;
@@ -126,7 +125,6 @@ public class ProfileManager {
 
     public void loadProfileInfo(Profile profile) {
         profile.getStats().setDivision(DivisionManager.getInstance().getDivision(profile));
-        profile.setSettingsGui(new ProfileSettingsGui(profile));
     }
 
     public void saveProfiles() {


### PR DESCRIPTION
The main thing I found is that the plugin was eagerly creating per-profile GUI objects for every stored player, plus per-custom-kit editor GUIs, even when those players were offline. On a server with lots of saved profiles, that can easily blow heap usage up before anyone really plays.

I changed it so those heavy UI objects are created only when a player actually opens them:
