### PR TITLE
Fix NPE

### DIFF
--- a/core/src/main/java/dev/nandi0813/practice/manager/gui/guis/MatchStatsGui.java
+++ b/core/src/main/java/dev/nandi0813/practice/manager/gui/guis/MatchStatsGui.java
@@ -69,10 +69,11 @@ public class MatchStatsGui extends GUI {
                 Inventory inventory = gui.get(round);
 
                 // Inventory Content
-                List<ItemStack> inventoryContent = Arrays.asList(roundStatistic.getEndInventory());
+                ItemStack[] endInv = roundStatistic.getEndInventory();
+                List<ItemStack> inventoryContent = endInv != null ? Arrays.asList(endInv) : Collections.emptyList();
                 List<ItemStack> firstLine = new ArrayList<>();
                 int healthPotionsLeft = 0;
-                for (int i = 0; i < 36; i++) {
+                for (int i = 0; i < 36 && i < inventoryContent.size(); i++) {
                     if (i < 9)
                         firstLine.add(inventoryContent.get(i));
 
@@ -84,8 +85,9 @@ public class MatchStatsGui extends GUI {
                 }
 
                 // Armor Content
-                List<ItemStack> armor = Arrays.asList(roundStatistic.getEndArmor());
-                for (int i = 36; i <= 39; i++)
+                ItemStack[] endArmorArray = roundStatistic.getEndArmor();
+                List<ItemStack> armor = endArmorArray != null ? Arrays.asList(endArmorArray) : Collections.emptyList();
+                for (int i = 36; i <= 39 && (i - 36) < armor.size(); i++)
                     inventory.setItem(i, armor.get(i - 36));
 
                 if (roundStatistic.getPotionThrown() != 0)


### PR DESCRIPTION
[12:26:21 WARN]: [ZonePracticePro] Plugin ZonePracticePro v7.6.0-dev-1-5b71893 generated an exception while executing task 388251
java.lang.NullPointerException
        at java.base/java.util.Objects.requireNonNull(Objects.java:220) ~[?:?]
        at java.base/java.util.Arrays$ArrayList.<init>(Arrays.java:4197) ~[?:?]
        at java.base/java.util.Arrays.asList(Arrays.java:4181) ~[?:?]
        at ZonePractice-Pro-7.6.0-dev-1-5b71893.jar//dev.nandi0813.practice.manager.gui.guis.MatchStatsGui.lambda$update$0(MatchStatsGui.java:72) ~[?:?]
        at org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:78) ~[universe-1.21.11.jar:1.21.11-e26d23f]
        at org.bukkit.craftbukkit.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57) ~[universe-1.21.11.jar:1.21.11-e26d23f]
        at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22) ~[universe-1.21.11.jar:1.21.11-e26d23f]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614) ~[?:?]
        at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]