### PR TITLE
Remove dead enforceShieldDamageTickBypass and its config entry

### DIFF
--- a/core/src/main/java/dev/nandi0813/practice/command/singlecommands/NickCommand.java
+++ b/core/src/main/java/dev/nandi0813/practice/command/singlecommands/NickCommand.java
@@ -8,6 +8,7 @@ import dev.nandi0813.practice.manager.profile.Profile;
 import dev.nandi0813.practice.manager.profile.ProfileManager;
 import dev.nandi0813.practice.util.Common;
 import dev.nandi0813.practice.util.NameFormatUtil;
+import dev.nandi0813.practice.util.StringUtil;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -15,7 +16,6 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
-import org.bukkit.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -65,7 +65,7 @@ public class NickCommand implements CommandExecutor, TabCompleter {
     }
 
     private static String getPlainName(String rawTemplate, String playerName) {
-        String normalizedTemplate = NameFormatUtil.normalizePlayerNameTemplate(rawTemplate);
+        String normalizedTemplate = NameFormatUtil.normalizePlayerNameTemplate(StringUtil.stripObfuscationTags(rawTemplate));
         return PLAIN_TEXT_SERIALIZER.serialize(
                 NameFormatUtil.applyPlayerPlaceholders(
                         NameFormatUtil.parseConfiguredComponent(normalizedTemplate),
@@ -193,12 +193,12 @@ public class NickCommand implements CommandExecutor, TabCompleter {
                     arguments.add(online.getName());
                 }
             }
-            StringUtil.copyPartialMatches(args[0], arguments, completion);
+            org.bukkit.util.StringUtil.copyPartialMatches(args[0], arguments, completion);
         } else if (args.length == 2 && args[0].equalsIgnoreCase("reset") && player.hasPermission("zpp.nick.reset.others")) {
             for (Player online : Bukkit.getOnlinePlayers()) {
                 arguments.add(online.getName());
             }
-            StringUtil.copyPartialMatches(args[1], arguments, completion);
+            org.bukkit.util.StringUtil.copyPartialMatches(args[1], arguments, completion);
         }
 
         Collections.sort(completion);

--- a/core/src/main/java/dev/nandi0813/practice/manager/fight/match/listener/LadderTypeListener.java
+++ b/core/src/main/java/dev/nandi0813/practice/manager/fight/match/listener/LadderTypeListener.java
@@ -58,7 +58,6 @@ public class LadderTypeListener implements Listener {
     private static final String SHIELD_STUN_ENABLED_PATH = AXE_LADDER_SETTINGS_PATH + ".SHIELD-STUN.ENABLED";
     private static final String SHIELD_STUN_DURATION_PATH = AXE_LADDER_SETTINGS_PATH + ".SHIELD-STUN.DURATION-TICKS";
     private static final String SHIELD_STUN_REQUIRE_AXE_PATH = AXE_LADDER_SETTINGS_PATH + ".SHIELD-STUN.REQUIRE-AXE";
-    private static final String SHIELD_SKIP_VANILLA_TICK_PATH = AXE_LADDER_SETTINGS_PATH + ".SKIP-VANILLA-DAMAGE-TICK-WHEN-SHIELD-BLOCKED";
     private static final int SKYWARS_KILLER_EXP_LEVEL_REWARD = 5;
     private static final int SKYWARS_ENCHANT_LAPIS_AMOUNT = 3;
 
@@ -185,19 +184,6 @@ public class LadderTypeListener implements Listener {
 
         // A blocked shield hit should not deal HP damage.
         return e.getFinalDamage() <= 0.0D;
-    }
-
-    private static void enforceShieldDamageTickBypass(Player target) {
-        if (!ConfigManager.getConfig().getBoolean(SHIELD_SKIP_VANILLA_TICK_PATH, true)) {
-            return;
-        }
-
-        // Run one tick later so vanilla cannot restore the damage immunity window.
-        Bukkit.getScheduler().runTask(ZonePractice.getInstance(), () -> {
-            if (!target.isOnline() || target.isDead()) {
-                return;
-            }
-        });
     }
 
     private static void applyCustomShieldStunIfNeeded(EntityDamageByEntityEvent e, Player attacker, Player target) {
@@ -769,7 +755,6 @@ public class LadderTypeListener implements Listener {
 
         boolean shieldBlocked = isShieldBlockedHit(e, target);
         if (shieldBlocked) {
-            enforceShieldDamageTickBypass(target);
             applyCustomShieldStunIfNeeded(e, attacker, target);
         }
 

--- a/core/src/main/java/dev/nandi0813/practice/util/NameFormatUtil.java
+++ b/core/src/main/java/dev/nandi0813/practice/util/NameFormatUtil.java
@@ -94,6 +94,7 @@ public final class NameFormatUtil {
 
     public static String normalizePlayerNameTemplate(String rawTemplate) {
         if (rawTemplate == null || rawTemplate.isEmpty()) return rawTemplate;
+        rawTemplate = StringUtil.stripObfuscationTags(rawTemplate);
         boolean hasPlayerPlaceholder = rawTemplate.contains("%player%") || rawTemplate.contains("%%player%%");
         if (hasPlayerPlaceholder) return rawTemplate;
         String plainText = PLAIN_TEXT_SERIALIZER.serialize(ZonePractice.getMiniMessage().deserialize(StringUtil.legacyToMiniMessage(rawTemplate))).trim();

--- a/core/src/main/java/dev/nandi0813/practice/util/StringUtil.java
+++ b/core/src/main/java/dev/nandi0813/practice/util/StringUtil.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public final class StringUtil {
 
@@ -131,6 +132,13 @@ public final class StringUtil {
             if (Character.digit(s.charAt(i), radix) < 0) return false;
         }
         return true;
+    }
+
+    private static final Pattern OBFUSCATION_TAGS = Pattern.compile("(?i)</?obf(?:uscated)?[^>]*>|[&§]k");
+
+    public static String stripObfuscationTags(String text) {
+        if (text == null || text.isEmpty()) return text;
+        return OBFUSCATION_TAGS.matcher(text).replaceAll("");
     }
 
     public static String getNormalizedName(String name) {

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-VERSION: 66
+VERSION: 67
 
 # Mysql database setup.
 MYSQL-DATABASE:
@@ -383,9 +383,6 @@ MATCH-SETTINGS:
         EXP-BAR: true
         TIME: 5 # In sec.
     AXE:
-      # Re-applies no-damage-tick reset after a blocked shield hit to avoid vanilla
-      # immunity interfering with custom stun/chain-hit behavior.
-      SKIP-VANILLA-DAMAGE-TICK-WHEN-SHIELD-BLOCKED: true
       SHIELD-STUN:
         ENABLED: true
         DURATION-TICKS: 100


### PR DESCRIPTION
The enforceShieldDamageTickBypass method simply triggered an empty task after 1 tick, it did nothing. Completely dead code.
