### PR TITLE
Dev

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.nandi0813</groupId>
         <artifactId>practice-parent</artifactId>
-        <version>7.7.0-SNAPSHOT</version>
+        <version>7.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>practice-core</artifactId>

--- a/core/src/main/java/dev/nandi0813/practice/manager/backend/ConfigManager.java
+++ b/core/src/main/java/dev/nandi0813/practice/manager/backend/ConfigManager.java
@@ -66,10 +66,6 @@ public enum ConfigManager {
         return getBoolean("MATCH-SETTINGS.SHOW-PLAYERS-IN-TAB");
     }
 
-    public static boolean isShowLobbyPlayersInMatch() {
-        return getBoolean("MATCH-SETTINGS.SHOW-LOBBY-PLAYERS-IN-MATCH");
-    }
-
     public static int getInt(String loc) {
         return getConfig().getInt(loc);
     }

--- a/core/src/main/java/dev/nandi0813/practice/manager/fight/match/Match.java
+++ b/core/src/main/java/dev/nandi0813/practice/manager/fight/match/Match.java
@@ -148,10 +148,7 @@ public abstract class Match extends BukkitRunnable implements Spectatable, dev.n
 
             for (Player online : Bukkit.getOnlinePlayers()) {
                 if (!this.players.contains(online)) {
-                    if (ConfigManager.isShowLobbyPlayersInMatch())
-                        PlayerHider.getInstance().showPlayer(player, online);
-                    else
-                        PlayerHider.getInstance().hidePlayer(player, online, true);
+                    PlayerHider.getInstance().hidePlayer(player, online, true);
 
                     if (!ConfigManager.isShowMatchPlayersInTab())
                         PlayerHider.getInstance().hidePlayer(online, player, false);

--- a/core/src/main/java/dev/nandi0813/practice/manager/spectator/SpectatorListener.java
+++ b/core/src/main/java/dev/nandi0813/practice/manager/spectator/SpectatorListener.java
@@ -10,6 +10,7 @@ import dev.nandi0813.practice.manager.profile.ProfileManager;
 import dev.nandi0813.practice.manager.profile.enums.ProfileStatus;
 import dev.nandi0813.practice.util.Cuboid;
 import dev.nandi0813.practice.util.interfaces.Spectatable;
+import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -131,10 +132,18 @@ public class SpectatorListener implements Listener {
         Player player = e.getPlayer();
         ensureSpectatorFlight(player);
 
-        // Some teleports or server versions can drop flight state right after teleport.
+        // The client ignores ability packets sent during a teleport until it has
+        // acknowledged the new position, so the flight state has to be re-sent after it.
         ZonePractice plugin = ZonePractice.getInstance();
         if (plugin != null && plugin.isEnabled()) {
-            org.bukkit.Bukkit.getScheduler().runTask(plugin, () -> ensureSpectatorFlight(player));
+            Bukkit.getScheduler().runTask(plugin, () -> ensureSpectatorFlight(player));
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                // Skip if the player is no longer a spectator by the time this runs.
+                if (player.isOnline() && hasSpectatorRestrictions(player)) {
+                    player.setAllowFlight(false);
+                    ensureSpectatorFlight(player);
+                }
+            }, 2L);
         }
     }
 

--- a/core/src/main/java/dev/nandi0813/practice/util/entityhider/PlayerHider.java
+++ b/core/src/main/java/dev/nandi0813/practice/util/entityhider/PlayerHider.java
@@ -56,10 +56,7 @@ public class PlayerHider implements Listener {
                  * Hide the player from the online.
                  */
                 if (onlineStatus.equals(ProfileStatus.MATCH) || onlineStatus.equals(ProfileStatus.EVENT) || onlineStatus.equals(ProfileStatus.FFA)) {
-                    if (ConfigManager.isShowLobbyPlayersInMatch())
-                        showPlayer(online, player);
-                    else
-                        hidePlayer(online, player, ConfigManager.isShowMatchPlayersInTab());
+                    hidePlayer(online, player, ConfigManager.isShowMatchPlayersInTab());
                 } else if (!onlineStatus.equals(ProfileStatus.SPECTATE) && onlineProfile.isHidePlayers()) {
                     hidePlayer(online, player, false);
                 } else if (profile.isHideFromPlayers() && !online.hasPermission("zpp.staffmode.see")) {
@@ -108,10 +105,7 @@ public class PlayerHider implements Listener {
                 }
 
                 // Handle the online player
-                if (onlineProfile.getStatus().equals(ProfileStatus.MATCH) || onlineProfile.getStatus().equals(ProfileStatus.EVENT) || onlineProfile.getStatus().equals(ProfileStatus.FFA)) {
-                    if (ConfigManager.isShowLobbyPlayersInMatch())
-                        showPlayer(online, player);
-                } else {
+                if (!(onlineProfile.getStatus().equals(ProfileStatus.MATCH) || onlineProfile.getStatus().equals(ProfileStatus.EVENT) || onlineProfile.getStatus().equals(ProfileStatus.FFA))) {
                     if (onlineProfile.isHidePlayers() && ServerManager.getInstance().getInWorld().get(online) == WorldEnum.LOBBY) {
                         hidePlayer(online, player, false);
                     } else if (!profile.isHideFromPlayers() || online.hasPermission("zpp.staffmode.see")) {

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -231,7 +231,6 @@ AUTO-SAVE:
 # Match settings
 MATCH-SETTINGS:
   SHOW-PLAYERS-IN-TAB: false # If true, players currently in a match/FFA/event remain visible in the tab list for lobby players (otherwise they are hidden).
-  SHOW-LOBBY-PLAYERS-IN-MATCH: false # If true, players in a match/FFA/event can see the players in the lobby (otherwise lobby players are hidden from them).
   TEAMS:
     TEAM1:
       NAME: "<blue>[B]"

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>dev.nandi0813</groupId>
         <artifactId>practice-parent</artifactId>
-        <version>7.7.0-SNAPSHOT</version>
+        <version>7.8.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.nandi0813</groupId>
     <artifactId>practice-parent</artifactId>
-    <version>7.7.0-SNAPSHOT</version>
+    <version>7.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>ZonePractice Pro</name>


### PR DESCRIPTION
[Remove the useless SHOW-PLAYERS-IN-TAB option.](https://github.com/ZoneDevelopement/ZonePractice-Pro/pull/626/commits/dda431ebdd4f6c9711df9877452652970b4537f4) 
^^ Because players could see the other players in the same map in different match  

[fix: restore spectator flight after teleport ability resync](https://github.com/ZoneDevelopement/ZonePractice-Pro/pull/626/commits/4bc3d12b8c3f82163d08e15e274b5ea91a08be06)
^^ Now it is possible to fly in spectator without clicking to the item Show/Hide Spectators (was a bug) and without move event force fly